### PR TITLE
fix(npm): Include package-lock.json

### DIFF
--- a/lib/npm.ts
+++ b/lib/npm.ts
@@ -8,7 +8,7 @@ const npmRelease = {
     [
       "@semantic-release/git",
       {
-        assets: ["package.json"],
+        assets: ["package.json", "package-lock.json"],
         message:
           "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cablanchard/semantic-release",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Include package-lock.json when updating github following npm release
version bump